### PR TITLE
autodetection for simple-schema and collection2: will enable filter and ...

### DIFF
--- a/lib/editable_text_common.js
+++ b/lib/editable_text_common.js
@@ -194,7 +194,7 @@ Meteor.methods({
 			data.context = EditableText._callback.call(data,'beforeInsert',data.context) || data.context;
       var new_id;
       if (hasPackageCollection2 && hasPackageSimpleSchema && !!Collection.simpleSchema()) {
-        new_id = Collection.insert(data.context, this.collection2Options, function (error, result) {
+        new_id = Collection.insert(data.context, EditableText.collection2Options, function (error, result) {
           data.status = {error: error, result: result};
         });
       } else {
@@ -246,7 +246,7 @@ Meteor.methods({
 			data.context = EditableText._callback.call(data,details && details.callbacks && details.callbacks[0] || 'beforeUpdate',data.context) || data.context;
       if (hasPackageCollection2 && hasPackageSimpleSchema && !!Collection.simpleSchema()) {
         var status;
-        Collection.update({_id:data.context._id}, modifier, this.collection2Options, function (error, result) {
+        Collection.update({_id:data.context._id}, modifier, EditableText.collection2Options, function (error, result) {
           status = {error: error, result: result};
         });
         data.status = status;

--- a/lib/editable_text_common.js
+++ b/lib/editable_text_common.js
@@ -61,6 +61,11 @@ EditableText.config = function(config) {
 		   throw new Meteor.Error(key + ' must be a boolean');
 		 }
 	   }
+    if (_.contains(['collection2Options'], key)) {
+      if (_.isObject(val)) {
+        EditableText[key] = val;
+      }
+    }
 	 });
   }
   else {
@@ -156,6 +161,8 @@ Meteor.methods({
 	check(transaction,Boolean);
 	check(data.objectTypeText,Match.OneOf(String,undefined));
 	check(details,Match.OneOf(Object,undefined));
+  var hasPackageCollection2 = !!Package['aldeed:collection2'];
+  var hasPackageSimpleSchema = !!Package['aldeed:simple-schema'];
 	var Collection = Mongo.Collection.get(data.collection);
 	if (Collection && EditableText.userCanEdit.call(data,data.context,Collection)) {
 	  if (Meteor.isServer) {
@@ -185,7 +192,14 @@ Meteor.methods({
 		  }
 		  else {
 			data.context = EditableText._callback.call(data,'beforeInsert',data.context) || data.context;
-			var new_id = Collection.insert(data.context);
+      var new_id;
+      if (hasPackageCollection2 && hasPackageSimpleSchema && !!Collection.simpleSchema()) {
+        new_id = Collection.insert(data.context, this.collection2Options, function (error, result) {
+          data.status = {error: error, result: result};
+        });
+      } else {
+			  new_id = Collection.insert(data.context);
+      }
 			EditableText._callback.call(data,'afterInsert',Collection.findOne({_id:new_id}));
 		  }
 		  return new_id;
@@ -230,7 +244,15 @@ Meteor.methods({
 		  }
 		  else {
 			data.context = EditableText._callback.call(data,details && details.callbacks && details.callbacks[0] || 'beforeUpdate',data.context) || data.context;
+      if (hasPackageCollection2 && hasPackageSimpleSchema && !!Collection.simpleSchema()) {
+        var status;
+        Collection.update({_id:data.context._id}, modifier, this.collection2Options, function (error, result) {
+          status = {error: error, result: result};
+        });
+        data.status = status;
+      } else {
 			Collection.update({_id:data.context._id},modifier);
+      }
 			EditableText._callback.call(data,details && details.callbacks && details.callbacks[1] || 'afterUpdate',data.context);
 		  }
 		  break;

--- a/lib/editable_text_server.js
+++ b/lib/editable_text_server.js
@@ -29,4 +29,4 @@ EditableText.sanitizeObject = function(obj,allow) {
   return obj;
 }
 
-EditableText.config({collection2Options:{filter: true, validate: true, tri: 'tra', tru: 'lala'}});
+EditableText.config({collection2Options:{filter: true, validate: true});

--- a/lib/editable_text_server.js
+++ b/lib/editable_text_server.js
@@ -28,3 +28,5 @@ EditableText.sanitizeObject = function(obj,allow) {
   });
   return obj;
 }
+
+EditableText.config({collection2Options:{filter: true, validate: true, tri: 'tra', tru: 'lala'}});


### PR DESCRIPTION
...validate settings and will send possible validation errors back to context.

So the result could be picked up by afterInsert / afterUpdate callback (e.g. to display alerts to user why the update failed)
