### PR TITLE
let EditableText have an options element

### DIFF
--- a/lib/editable_text.html
+++ b/lib/editable_text.html
@@ -1,8 +1,9 @@
 <template name="editableText">
-  {{> editable_text_widget context=context collection=collection field=field value=value textarea=textarea wysiwyg=wysiwyg acceptEmpty=acceptEmpty removeEmpty=removeEmpty eventType=eventType type=type objectTypeText=objectTypeText class=class inputClass=inputClass autoInsert=autoInsert beforeInsert=beforeInsert afterInsert=afterInsert wysiwygStyle=wysiwygStyle style=style inputStyle=inputStyle substitute=substitute title=title userCanEdit=userCanEdit useTransaction=useTransaction beforeUpdate=beforeUpdate afterUpdate=afterUpdate beforeRemove=beforeRemove afterRemove=afterRemove beforeRemove=beforeRemove afterRemove=afterRemove placeholder=placeholder saveOnFocusout=saveOnFocusout trustHtml=trustHtml useMethod=useMethod toolbarPosition=toolbarPosition}}
+  {{> editable_text_widget  options=options context=context collection=collection field=field value=value textarea=textarea wysiwyg=wysiwyg acceptEmpty=acceptEmpty removeEmpty=removeEmpty eventType=eventType type=type objectTypeText=objectTypeText class=class inputClass=inputClass autoInsert=autoInsert beforeInsert=beforeInsert afterInsert=afterInsert wysiwygStyle=wysiwygStyle style=style inputStyle=inputStyle substitute=substitute title=title userCanEdit=userCanEdit useTransaction=useTransaction beforeUpdate=beforeUpdate afterUpdate=afterUpdate beforeRemove=beforeRemove afterRemove=afterRemove beforeRemove=beforeRemove afterRemove=afterRemove placeholder=placeholder saveOnFocusout=saveOnFocusout trustHtml=trustHtml useMethod=useMethod toolbarPosition=toolbarPosition}}
 </template>
 
-<template name="editable_text_widget"> 
+<template name="editable_text_widget">
+  {{initOptions}}
   {{#if editing}}
     {{#if textarea}}
       <textarea class="text-area-edit {{inputClass}}" placeholder="{{placeholder}}" title="{{#if trustHtml}}Hold SHIFT and press ENTER for a new line{{/if}}" style="{{inputStyle}}">{{value}}</textarea>

--- a/lib/editable_text.js
+++ b/lib/editable_text.js
@@ -301,6 +301,20 @@ Template.editable_text_widget.helpers({
   
   toolsPosition : function(pos) {
     return this.toolbarPosition === pos;
+  },
+
+  initOptions: function () {
+    data = this;
+    if (data.options) {
+      _.each(data.options, function (value, key) {
+        if (data[key] === undefined) {
+          data[key] = value;
+        }
+      });
+      if (data.options.context !== undefined) {
+        data.context = data.options.context;
+      }
+    }
   }
   
 });


### PR DESCRIPTION
In template you can give the {{> editableText}} now options. It will automatically apply those options to the regular options.

Benefit: the call could be shortened to a minimum

``` html
{{> editableText options=opts}}
```

where _opts_ or whatever the name can be is a helper of the Template, where the EditableText is called.
This makes the template code more readable, as common options for a editable text field could be set by the helper and only the detail is in the template, e.g.

``` html
{{> editableText options=opts field="name"}}
```

and in the helpers:

``` javascript
Template.myTemplate.helpers({
  opts: function () {
    return {
      context: this.mydata,
      collection: "myCollection",
      substitute: '<i class="fa fa-pencil"></i>',
      afterUpdate: "afterUpdate"
    };
  }
});

```
